### PR TITLE
Add persisted inscription transfer history indexes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
     - master
+    - ordnet
   pull_request:
     branches:
     - master
+    - ordnet
 
 defaults:
   run:

--- a/src/index.rs
+++ b/src/index.rs
@@ -7,6 +7,7 @@ use {
     event::Event,
     lot::Lot,
     reorg::Reorg,
+    transfer_event::{InscriptionTransferEvent, InscriptionTransferEventValue},
     updater::Updater,
     utxo_entry::{ParsedUtxoEntry, UtxoEntry, UtxoEntryBuf},
   },
@@ -39,7 +40,7 @@ use {
   },
 };
 
-pub use self::entry::RuneEntry;
+pub use self::{entry::RuneEntry, transfer_history::InscriptionTransferHistoryEntry};
 
 pub(crate) mod entry;
 pub mod event;
@@ -47,6 +48,8 @@ mod fetcher;
 mod lot;
 mod reorg;
 mod rtx;
+mod transfer_event;
+mod transfer_history;
 mod updater;
 mod utxo_entry;
 
@@ -57,17 +60,24 @@ pub(crate) mod testing;
 #[path = "index/brc20_filter_tests.rs"]
 mod brc20_filter_tests;
 
+#[cfg(test)]
+#[path = "index/transfer_history_tests.rs"]
+mod transfer_history_tests;
+
 const SCHEMA_VERSION: u64 = 33;
 pub(crate) const EXCLUDE_BRC20: bool = true;
 
 define_multimap_table! { LATEST_CHILD_SEQUENCE_NUMBER_TO_COLLECTION_SEQUENCE_NUMBER, u32, u32 }
+define_multimap_table! { SEQUENCE_NUMBER_TO_TRANSFER_NUMBER, u32, u64 }
 define_multimap_table! { SAT_TO_SEQUENCE_NUMBER, u64, u32 }
+define_multimap_table! { SCRIPT_PUBKEY_TO_TRANSFER_NUMBER, &[u8], u64 }
 define_multimap_table! { SCRIPT_PUBKEY_TO_OUTPOINT, &[u8], OutPointValue }
 define_multimap_table! { SEQUENCE_NUMBER_TO_CHILDREN, u32, u32 }
 define_table! { COLLECTION_SEQUENCE_NUMBER_TO_LATEST_CHILD_SEQUENCE_NUMBER, u32, u32 }
 define_table! { GALLERY_SEQUENCE_NUMBERS, u32, () }
 define_table! { HEIGHT_TO_BLOCK_HEADER, u32, &HeaderValue }
 define_table! { HEIGHT_TO_LAST_SEQUENCE_NUMBER, u32, u32 }
+define_table! { HEIGHT_TO_LAST_TRANSFER_NUMBER, u32, u64 }
 define_table! { HOME_INSCRIPTIONS, u32, InscriptionIdValue }
 define_table! { INSCRIPTION_ID_TO_SEQUENCE_NUMBER, InscriptionIdValue, u32 }
 define_table! { INSCRIPTION_NUMBER_TO_SEQUENCE_NUMBER, i32, u32 }
@@ -82,6 +92,7 @@ define_table! { SEQUENCE_NUMBER_TO_INSCRIPTION_ENTRY, u32, InscriptionEntryValue
 define_table! { SEQUENCE_NUMBER_TO_RUNE_ID, u32, RuneIdValue }
 define_table! { SEQUENCE_NUMBER_TO_SATPOINT, u32, &SatPointValue }
 define_table! { STATISTIC_TO_COUNT, u64, u64 }
+define_table! { TRANSFER_NUMBER_TO_EVENT, u64, InscriptionTransferEventValue }
 define_table! { TRANSACTION_ID_TO_RUNE, &TxidValue, u128 }
 define_table! { TRANSACTION_ID_TO_TRANSACTION, &TxidValue, &[u8] }
 define_table! { WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP, u32, u128 }
@@ -328,13 +339,16 @@ impl Index {
         tx.set_quick_repair(true);
 
         tx.open_multimap_table(LATEST_CHILD_SEQUENCE_NUMBER_TO_COLLECTION_SEQUENCE_NUMBER)?;
+        tx.open_multimap_table(SEQUENCE_NUMBER_TO_TRANSFER_NUMBER)?;
         tx.open_multimap_table(SAT_TO_SEQUENCE_NUMBER)?;
+        tx.open_multimap_table(SCRIPT_PUBKEY_TO_TRANSFER_NUMBER)?;
         tx.open_multimap_table(SCRIPT_PUBKEY_TO_OUTPOINT)?;
         tx.open_multimap_table(SEQUENCE_NUMBER_TO_CHILDREN)?;
         tx.open_table(COLLECTION_SEQUENCE_NUMBER_TO_LATEST_CHILD_SEQUENCE_NUMBER)?;
         tx.open_table(GALLERY_SEQUENCE_NUMBERS)?;
         tx.open_table(HEIGHT_TO_BLOCK_HEADER)?;
         tx.open_table(HEIGHT_TO_LAST_SEQUENCE_NUMBER)?;
+        tx.open_table(HEIGHT_TO_LAST_TRANSFER_NUMBER)?;
         tx.open_table(HOME_INSCRIPTIONS)?;
         tx.open_table(INSCRIPTION_ID_TO_SEQUENCE_NUMBER)?;
         tx.open_table(INSCRIPTION_NUMBER_TO_SEQUENCE_NUMBER)?;
@@ -350,6 +364,7 @@ impl Index {
         tx.open_table(SEQUENCE_NUMBER_TO_SATPOINT)?;
         tx.open_table(TRANSACTION_ID_TO_RUNE)?;
         tx.open_table(WRITE_TRANSACTION_STARTING_BLOCK_COUNT_TO_TIMESTAMP)?;
+        tx.open_table(TRANSFER_NUMBER_TO_EVENT)?;
 
         {
           let mut statistics = tx.open_table(STATISTIC_TO_COUNT)?;

--- a/src/index/transfer_event.rs
+++ b/src/index/transfer_event.rs
@@ -1,0 +1,60 @@
+use super::entry::Entry;
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct InscriptionTransferEvent {
+  pub block_height: u32,
+  pub sequence_number: u32,
+  pub from_script_pubkey: Vec<u8>,
+  pub to_script_pubkey: Option<Vec<u8>>,
+}
+
+pub(crate) type InscriptionTransferEventValue = (
+  u32,             // block height
+  u32,             // sequence number
+  Vec<u8>,         // from script pubkey
+  Option<Vec<u8>>, // to script pubkey
+);
+
+impl Entry for InscriptionTransferEvent {
+  type Value = InscriptionTransferEventValue;
+
+  fn load(
+    (block_height, sequence_number, from_script_pubkey, to_script_pubkey): InscriptionTransferEventValue,
+  ) -> Self {
+    Self {
+      block_height,
+      sequence_number,
+      from_script_pubkey,
+      to_script_pubkey,
+    }
+  }
+
+  fn store(self) -> Self::Value {
+    (
+      self.block_height,
+      self.sequence_number,
+      self.from_script_pubkey,
+      self.to_script_pubkey,
+    )
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn inscription_transfer_event_entry() {
+    let event = InscriptionTransferEvent {
+      block_height: 5,
+      sequence_number: 6,
+      from_script_pubkey: vec![1, 2, 3],
+      to_script_pubkey: Some(vec![4, 5, 6]),
+    };
+
+    let value = (5, 6, vec![1, 2, 3], Some(vec![4, 5, 6]));
+
+    assert_eq!(event.clone().store(), value);
+    assert_eq!(InscriptionTransferEvent::load(value), event);
+  }
+}

--- a/src/index/transfer_history.rs
+++ b/src/index/transfer_history.rs
@@ -1,0 +1,179 @@
+use super::*;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct InscriptionTransferHistoryEntry {
+  pub block_height: u32,
+  pub inscription_id: InscriptionId,
+  pub sequence_number: u32,
+  pub from_address: Option<String>,
+  pub to_address: Option<String>,
+}
+
+impl Index {
+  pub fn get_inscription_transfer_history_paginated(
+    &self,
+    inscription_id: InscriptionId,
+    page_size: usize,
+    page_index: usize,
+  ) -> Result<(Vec<InscriptionTransferHistoryEntry>, bool)> {
+    if !self.has_address_index() {
+      return Ok((Vec::new(), false));
+    }
+
+    let rtx = self.database.begin_read()?;
+
+    let inscription_id_to_sequence_number = rtx.open_table(INSCRIPTION_ID_TO_SEQUENCE_NUMBER)?;
+    let sequence_number_to_transfer_number =
+      rtx.open_multimap_table(SEQUENCE_NUMBER_TO_TRANSFER_NUMBER)?;
+    let sequence_number_to_inscription_entry =
+      rtx.open_table(SEQUENCE_NUMBER_TO_INSCRIPTION_ENTRY)?;
+    let transfer_number_to_event = rtx.open_table(TRANSFER_NUMBER_TO_EVENT)?;
+
+    let Some(sequence_number) = inscription_id_to_sequence_number
+      .get(&inscription_id.store())?
+      .map(|guard| guard.value())
+    else {
+      return Ok((Vec::new(), false));
+    };
+
+    let mut entries = sequence_number_to_transfer_number
+      .get(sequence_number)?
+      .rev()
+      .skip(page_index.saturating_mul(page_size))
+      .take(page_size.saturating_add(1))
+      .map(|result| {
+        let transfer_number = result?.value();
+        self.load_transfer_history_entry(
+          &transfer_number_to_event,
+          &sequence_number_to_inscription_entry,
+          transfer_number,
+        )
+      })
+      .collect::<Result<Vec<InscriptionTransferHistoryEntry>>>()?;
+
+    let more = entries.len() > page_size;
+
+    if more {
+      entries.pop();
+    }
+
+    Ok((entries, more))
+  }
+
+  pub fn get_transfer_history_in_block(
+    &self,
+    block_height: u32,
+  ) -> Result<Vec<InscriptionTransferHistoryEntry>> {
+    if !self.has_address_index() {
+      return Ok(Vec::new());
+    }
+
+    let rtx = self.database.begin_read()?;
+
+    let height_to_last_transfer_number = rtx.open_table(HEIGHT_TO_LAST_TRANSFER_NUMBER)?;
+    let sequence_number_to_inscription_entry =
+      rtx.open_table(SEQUENCE_NUMBER_TO_INSCRIPTION_ENTRY)?;
+    let transfer_number_to_event = rtx.open_table(TRANSFER_NUMBER_TO_EVENT)?;
+
+    let Some(newest_transfer_number) = height_to_last_transfer_number
+      .get(&block_height)?
+      .map(|guard| guard.value())
+    else {
+      return Ok(Vec::new());
+    };
+
+    let oldest_transfer_number = height_to_last_transfer_number
+      .get(block_height.saturating_sub(1))?
+      .map(|guard| guard.value())
+      .unwrap_or(0);
+
+    (oldest_transfer_number..newest_transfer_number)
+      .map(|transfer_number| {
+        self.load_transfer_history_entry(
+          &transfer_number_to_event,
+          &sequence_number_to_inscription_entry,
+          transfer_number,
+        )
+      })
+      .collect()
+  }
+
+  pub fn get_address_transfer_history_paginated(
+    &self,
+    address: &Address,
+    page_size: usize,
+    page_index: usize,
+  ) -> Result<Option<(Vec<InscriptionTransferHistoryEntry>, bool)>> {
+    if !self.has_address_index() {
+      return Ok(None);
+    }
+
+    let rtx = self.database.begin_read()?;
+
+    let script_pubkey_to_transfer_number =
+      rtx.open_multimap_table(SCRIPT_PUBKEY_TO_TRANSFER_NUMBER)?;
+    let sequence_number_to_inscription_entry =
+      rtx.open_table(SEQUENCE_NUMBER_TO_INSCRIPTION_ENTRY)?;
+    let transfer_number_to_event = rtx.open_table(TRANSFER_NUMBER_TO_EVENT)?;
+
+    let mut entries = script_pubkey_to_transfer_number
+      .get(address.script_pubkey().as_bytes())?
+      .rev()
+      .skip(page_index.saturating_mul(page_size))
+      .take(page_size.saturating_add(1))
+      .map(|result| {
+        let transfer_number = result?.value();
+        self.load_transfer_history_entry(
+          &transfer_number_to_event,
+          &sequence_number_to_inscription_entry,
+          transfer_number,
+        )
+      })
+      .collect::<Result<Vec<InscriptionTransferHistoryEntry>>>()?;
+
+    let more = entries.len() > page_size;
+
+    if more {
+      entries.pop();
+    }
+
+    Ok(Some((entries, more)))
+  }
+
+  fn load_transfer_history_entry(
+    &self,
+    transfer_number_to_event: &impl ReadableTable<u64, InscriptionTransferEventValue>,
+    sequence_number_to_inscription_entry: &impl ReadableTable<u32, InscriptionEntryValue>,
+    transfer_number: u64,
+  ) -> Result<InscriptionTransferHistoryEntry> {
+    let event = transfer_number_to_event
+      .get(&transfer_number)?
+      .map(|entry| InscriptionTransferEvent::load(entry.value()))
+      .unwrap();
+
+    let inscription_id = sequence_number_to_inscription_entry
+      .get(event.sequence_number)?
+      .map(|entry| InscriptionEntry::load(entry.value()).id)
+      .unwrap();
+
+    Ok(InscriptionTransferHistoryEntry {
+      block_height: event.block_height,
+      inscription_id,
+      sequence_number: event.sequence_number,
+      from_address: self.script_pubkey_to_address(&event.from_script_pubkey),
+      to_address: event
+        .to_script_pubkey
+        .as_deref()
+        .and_then(|script_pubkey| self.script_pubkey_to_address(script_pubkey)),
+    })
+  }
+
+  fn script_pubkey_to_address(&self, script_pubkey: &[u8]) -> Option<String> {
+    self
+      .settings
+      .chain()
+      .address_from_script(&ScriptBuf::from_bytes(script_pubkey.to_vec()))
+      .ok()
+      .map(|address| address.to_string())
+  }
+}

--- a/src/index/transfer_history_tests.rs
+++ b/src/index/transfer_history_tests.rs
@@ -1,0 +1,594 @@
+use {super::*, crate::index::testing::Context};
+
+#[test]
+fn inscription_transfer_history_records_and_orders_newest_first() {
+  let context = Context::builder().arg("--index-addresses").build();
+
+  context.mine_blocks(2);
+
+  let create_txid = context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
+    outputs: 1,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let inscription_id = InscriptionId {
+    txid: create_txid,
+    index: 0,
+  };
+
+  let transfer_1_txid = context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(3, 1, 0, Witness::new())],
+    outputs: 1,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let transfer_2_txid = context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(4, 1, 0, Witness::new())],
+    outputs: 1,
+    p2tr: true,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let (history, more) = context
+    .index
+    .get_inscription_transfer_history_paginated(inscription_id, 10, 0)
+    .unwrap();
+
+  let create_transaction = context.index.get_transaction(create_txid).unwrap().unwrap();
+  let transfer_1_transaction = context
+    .index
+    .get_transaction(transfer_1_txid)
+    .unwrap()
+    .unwrap();
+  let transfer_2_transaction = context
+    .index
+    .get_transaction(transfer_2_txid)
+    .unwrap()
+    .unwrap();
+
+  let create_address = context
+    .index
+    .settings
+    .chain()
+    .address_from_script(&create_transaction.output[0].script_pubkey)
+    .unwrap()
+    .to_string();
+  let transfer_1_address = context
+    .index
+    .settings
+    .chain()
+    .address_from_script(&transfer_1_transaction.output[0].script_pubkey)
+    .unwrap()
+    .to_string();
+  let transfer_2_address = context
+    .index
+    .settings
+    .chain()
+    .address_from_script(&transfer_2_transaction.output[0].script_pubkey)
+    .unwrap()
+    .to_string();
+
+  assert!(!more);
+  assert_eq!(history.len(), 3);
+
+  assert_eq!(history[0].inscription_id, inscription_id);
+  assert_eq!(history[0].from_address, Some(transfer_1_address.clone()));
+  assert_eq!(history[0].to_address, Some(transfer_2_address));
+
+  assert_eq!(history[1].inscription_id, inscription_id);
+  assert_eq!(history[1].from_address, Some(create_address.clone()));
+  assert_eq!(history[1].to_address, Some(transfer_1_address));
+
+  assert_eq!(history[2].inscription_id, inscription_id);
+  assert_eq!(history[2].from_address, None);
+  assert_eq!(history[2].to_address, Some(create_address));
+}
+
+#[test]
+fn address_transfer_history_tracks_send_and_receive_for_standard_transfer() {
+  let context = Context::builder().arg("--index-addresses").build();
+
+  context.mine_blocks(2);
+
+  let create_txid = context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
+    outputs: 1,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let inscription_id = InscriptionId {
+    txid: create_txid,
+    index: 0,
+  };
+
+  let transfer_txid = context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(3, 1, 0, Witness::new())],
+    outputs: 1,
+    p2tr: true,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let create_transaction = context.index.get_transaction(create_txid).unwrap().unwrap();
+  let transfer_transaction = context
+    .index
+    .get_transaction(transfer_txid)
+    .unwrap()
+    .unwrap();
+
+  let sender_address = context
+    .index
+    .settings
+    .chain()
+    .address_from_script(&create_transaction.output[0].script_pubkey)
+    .unwrap();
+
+  let receiver_address = context
+    .index
+    .settings
+    .chain()
+    .address_from_script(&transfer_transaction.output[0].script_pubkey)
+    .unwrap();
+
+  let (sender_history, sender_more) = context
+    .index
+    .get_address_transfer_history_paginated(&sender_address, 10, 0)
+    .unwrap()
+    .unwrap();
+
+  assert!(!sender_more);
+  assert_eq!(sender_history.len(), 2);
+  assert_eq!(sender_history[0].inscription_id, inscription_id);
+  assert_eq!(
+    sender_history[0].from_address,
+    Some(sender_address.to_string())
+  );
+  assert_eq!(
+    sender_history[0].to_address,
+    Some(receiver_address.to_string())
+  );
+  assert_eq!(sender_history[1].inscription_id, inscription_id);
+  assert_eq!(sender_history[1].from_address, None);
+  assert_eq!(
+    sender_history[1].to_address,
+    Some(sender_address.to_string())
+  );
+
+  let (receiver_history, receiver_more) = context
+    .index
+    .get_address_transfer_history_paginated(&receiver_address, 10, 0)
+    .unwrap()
+    .unwrap();
+
+  assert!(!receiver_more);
+  assert_eq!(receiver_history.len(), 1);
+  assert_eq!(receiver_history[0], sender_history[0]);
+}
+
+#[test]
+fn address_transfer_history_tracks_burn_sender_only_for_op_return() {
+  let context = Context::builder().arg("--index-addresses").build();
+
+  context.mine_blocks(2);
+
+  let create_txid = context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
+    outputs: 1,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let transfer_txid = context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(3, 1, 0, Witness::new())],
+    outputs: 0,
+    op_return_index: Some(0),
+    op_return_value: Some(50 * COIN_VALUE),
+    op_return: Some(
+      script::Builder::new()
+        .push_opcode(opcodes::all::OP_RETURN)
+        .into_script(),
+    ),
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let create_transaction = context.index.get_transaction(create_txid).unwrap().unwrap();
+  let sender_address = context
+    .index
+    .settings
+    .chain()
+    .address_from_script(&create_transaction.output[0].script_pubkey)
+    .unwrap();
+
+  let (sender_history, sender_more) = context
+    .index
+    .get_address_transfer_history_paginated(&sender_address, 10, 0)
+    .unwrap()
+    .unwrap();
+
+  assert!(!sender_more);
+  assert_eq!(sender_history.len(), 2);
+  assert_eq!(
+    sender_history[0].from_address,
+    Some(sender_address.to_string())
+  );
+  assert_eq!(sender_history[0].to_address, None);
+  assert_eq!(sender_history[1].from_address, None);
+  assert_eq!(
+    sender_history[1].to_address,
+    Some(sender_address.to_string())
+  );
+
+  let transfer_transaction = context
+    .index
+    .get_transaction(transfer_txid)
+    .unwrap()
+    .unwrap();
+  let rtx = context.index.database.begin_read().unwrap();
+  let script_pubkey_to_transfer_number = rtx
+    .open_multimap_table(SCRIPT_PUBKEY_TO_TRANSFER_NUMBER)
+    .unwrap();
+
+  assert_eq!(
+    script_pubkey_to_transfer_number
+      .get(transfer_transaction.output[0].script_pubkey.as_bytes())
+      .unwrap()
+      .count(),
+    0
+  );
+}
+
+#[test]
+fn spendable_non_address_scripts_are_persisted_in_transfer_events() {
+  let context = Context::builder().arg("--index-addresses").build();
+
+  context.mine_blocks(2);
+
+  let create_txid = context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
+    outputs: 1,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let non_address_script = script::Builder::new()
+    .push_opcode(opcodes::all::OP_PUSHNUM_1)
+    .into_script();
+
+  context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(3, 1, 0, Witness::new())],
+    outputs: 0,
+    op_return_index: Some(0),
+    op_return_value: Some(50 * COIN_VALUE),
+    op_return: Some(non_address_script.clone()),
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(4, 1, 0, Witness::new())],
+    outputs: 1,
+    p2tr: true,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let inscription_id = InscriptionId {
+    txid: create_txid,
+    index: 0,
+  };
+
+  let rtx = context.index.database.begin_read().unwrap();
+  let inscription_id_to_sequence_number =
+    rtx.open_table(INSCRIPTION_ID_TO_SEQUENCE_NUMBER).unwrap();
+  let sequence_number_to_transfer_number = rtx
+    .open_multimap_table(SEQUENCE_NUMBER_TO_TRANSFER_NUMBER)
+    .unwrap();
+  let transfer_number_to_event = rtx.open_table(TRANSFER_NUMBER_TO_EVENT).unwrap();
+  let script_pubkey_to_transfer_number = rtx
+    .open_multimap_table(SCRIPT_PUBKEY_TO_TRANSFER_NUMBER)
+    .unwrap();
+
+  let sequence_number = inscription_id_to_sequence_number
+    .get(&inscription_id.store())
+    .unwrap()
+    .unwrap()
+    .value();
+
+  let events = sequence_number_to_transfer_number
+    .get(sequence_number)
+    .unwrap()
+    .map(|result| {
+      let transfer_number = result.unwrap().value();
+      let event = transfer_number_to_event
+        .get(&transfer_number)
+        .unwrap()
+        .unwrap();
+      InscriptionTransferEvent::load(event.value())
+    })
+    .collect::<Vec<_>>();
+
+  assert_eq!(events.len(), 3);
+  assert!(
+    events
+      .iter()
+      .any(|event| { event.to_script_pubkey.as_deref() == Some(non_address_script.as_bytes()) })
+  );
+  assert!(
+    events
+      .iter()
+      .any(|event| { event.from_script_pubkey.as_slice() == non_address_script.as_bytes() })
+  );
+  assert_eq!(
+    script_pubkey_to_transfer_number
+      .get(non_address_script.as_bytes())
+      .unwrap()
+      .count(),
+    0
+  );
+}
+
+#[test]
+fn address_transfer_history_requires_address_index() {
+  let context = Context::builder().build();
+
+  context.mine_blocks(2);
+
+  let create_txid = context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
+    outputs: 1,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let transfer_txid = context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(3, 1, 0, Witness::new())],
+    outputs: 1,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let transfer_transaction = context
+    .index
+    .get_transaction(transfer_txid)
+    .unwrap()
+    .unwrap();
+  let address = context
+    .index
+    .settings
+    .chain()
+    .address_from_script(&transfer_transaction.output[0].script_pubkey)
+    .unwrap();
+
+  assert_eq!(
+    context
+      .index
+      .get_address_transfer_history_paginated(&address, 10, 0)
+      .unwrap(),
+    None
+  );
+  assert_eq!(
+    context
+      .index
+      .get_inscription_transfer_history_paginated(
+        InscriptionId {
+          txid: create_txid,
+          index: 0,
+        },
+        10,
+        0,
+      )
+      .unwrap()
+      .0
+      .len(),
+    0
+  );
+
+  assert_eq!(
+    context
+      .index
+      .get_transfer_history_in_block(4)
+      .unwrap()
+      .len(),
+    0
+  );
+}
+
+#[test]
+fn transfer_history_pagination_more_flag() {
+  let context = Context::builder().arg("--index-addresses").build();
+
+  context.mine_blocks(2);
+
+  let create_txid = context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
+    outputs: 1,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let inscription_id = InscriptionId {
+    txid: create_txid,
+    index: 0,
+  };
+
+  context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(3, 1, 0, Witness::new())],
+    outputs: 1,
+    ..default()
+  });
+  context.mine_blocks(1);
+
+  context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(4, 1, 0, Witness::new())],
+    outputs: 1,
+    ..default()
+  });
+  context.mine_blocks(1);
+
+  context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(5, 1, 0, Witness::new())],
+    outputs: 1,
+    ..default()
+  });
+  context.mine_blocks(1);
+
+  let (page_0, page_0_more) = context
+    .index
+    .get_inscription_transfer_history_paginated(inscription_id, 2, 0)
+    .unwrap();
+
+  assert!(page_0_more);
+  assert_eq!(page_0.len(), 2);
+  assert!(page_0[0].block_height > page_0[1].block_height);
+
+  let (page_1, page_1_more) = context
+    .index
+    .get_inscription_transfer_history_paginated(inscription_id, 2, 1)
+    .unwrap();
+
+  assert!(!page_1_more);
+  assert_eq!(page_1.len(), 2);
+  assert!(page_1[0].block_height < page_0[1].block_height);
+  assert!(page_1[1].block_height <= page_1[0].block_height);
+}
+
+#[test]
+fn transfer_history_in_block_uses_height_boundaries() {
+  let context = Context::builder().arg("--index-addresses").build();
+
+  context.mine_blocks(2);
+
+  let create_txid = context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
+    outputs: 1,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let inscription_id = InscriptionId {
+    txid: create_txid,
+    index: 0,
+  };
+
+  context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(3, 1, 0, Witness::new())],
+    outputs: 1,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(4, 1, 0, Witness::new())],
+    outputs: 1,
+    p2tr: true,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let (history, more) = context
+    .index
+    .get_inscription_transfer_history_paginated(inscription_id, 10, 0)
+    .unwrap();
+  assert!(!more);
+  assert_eq!(history.len(), 3);
+
+  let newest_entry = history[0].clone();
+  let middle_entry = history[1].clone();
+  let oldest_entry = history[2].clone();
+
+  assert!(
+    context
+      .index
+      .get_transfer_history_in_block(oldest_entry.block_height.saturating_sub(1))
+      .unwrap()
+      .is_empty()
+  );
+
+  assert_eq!(
+    context
+      .index
+      .get_transfer_history_in_block(oldest_entry.block_height)
+      .unwrap(),
+    vec![oldest_entry]
+  );
+  assert_eq!(
+    context
+      .index
+      .get_transfer_history_in_block(middle_entry.block_height)
+      .unwrap(),
+    vec![middle_entry]
+  );
+  assert_eq!(
+    context
+      .index
+      .get_transfer_history_in_block(newest_entry.block_height)
+      .unwrap(),
+    vec![newest_entry]
+  );
+}
+
+#[test]
+fn sender_receiver_same_script_is_deduped() {
+  let context = Context::builder().arg("--index-addresses").build();
+
+  context.mine_blocks(2);
+
+  let create_txid = context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(1, 0, 0, inscription("text/plain", "hello").to_witness())],
+    outputs: 1,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(3, 1, 0, Witness::new())],
+    outputs: 1,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let create_transaction = context.index.get_transaction(create_txid).unwrap().unwrap();
+  let address = context
+    .index
+    .settings
+    .chain()
+    .address_from_script(&create_transaction.output[0].script_pubkey)
+    .unwrap();
+
+  let (history, more) = context
+    .index
+    .get_address_transfer_history_paginated(&address, 10, 0)
+    .unwrap()
+    .unwrap();
+
+  assert!(!more);
+  assert_eq!(history.len(), 2);
+  assert_eq!(history[0].from_address, Some(address.to_string()));
+  assert_eq!(history[0].to_address, Some(address.to_string()));
+  assert_eq!(history[1].from_address, None);
+  assert_eq!(history[1].to_address, Some(address.to_string()));
+}

--- a/src/index/transfer_history_tests.rs
+++ b/src/index/transfer_history_tests.rs
@@ -592,3 +592,56 @@ fn sender_receiver_same_script_is_deduped() {
   assert_eq!(history[1].from_address, None);
   assert_eq!(history[1].to_address, Some(address.to_string()));
 }
+
+#[test]
+fn unbound_inscription_creation_has_no_transfer_history_event() {
+  let context = Context::builder().arg("--index-addresses").build();
+
+  context.mine_blocks(1);
+
+  context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(1, 0, 0, Default::default())],
+    fee: 50 * COIN_VALUE,
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let txid = context.core.broadcast_tx(TransactionTemplate {
+    inputs: &[(2, 1, 0, inscription("text/plain", "hello").to_witness())],
+    ..default()
+  });
+
+  context.mine_blocks(1);
+
+  let inscription_id = InscriptionId { txid, index: 0 };
+
+  let (history, more) = context
+    .index
+    .get_inscription_transfer_history_paginated(inscription_id, 10, 0)
+    .unwrap();
+
+  assert!(!more);
+  assert!(history.is_empty());
+
+  let create_transaction = context.index.get_transaction(txid).unwrap().unwrap();
+  let destination_address = context
+    .index
+    .settings
+    .chain()
+    .address_from_script(&create_transaction.output[0].script_pubkey)
+    .unwrap();
+
+  let (address_history, address_more) = context
+    .index
+    .get_address_transfer_history_paginated(&destination_address, 10, 0)
+    .unwrap()
+    .unwrap();
+
+  assert!(!address_more);
+  assert!(address_history.is_empty());
+
+  let rtx = context.index.database.begin_read().unwrap();
+  let transfer_number_to_event = rtx.open_table(TRANSFER_NUMBER_TO_EVENT).unwrap();
+  assert_eq!(transfer_number_to_event.len().unwrap(), 0);
+}

--- a/src/index/updater.rs
+++ b/src/index/updater.rs
@@ -11,6 +11,7 @@ use {
 mod inscription_updater;
 mod inscription_updater_filtered;
 mod rune_updater;
+mod transfer_history_indexer;
 
 pub(crate) struct BlockData {
   pub(crate) header: Header,
@@ -426,7 +427,10 @@ impl Updater<'_> {
       wtx.open_table(COLLECTION_SEQUENCE_NUMBER_TO_LATEST_CHILD_SEQUENCE_NUMBER)?;
     let mut gallery_sequence_numbers = wtx.open_table(GALLERY_SEQUENCE_NUMBERS)?;
     let mut height_to_last_sequence_number = wtx.open_table(HEIGHT_TO_LAST_SEQUENCE_NUMBER)?;
+    let mut height_to_last_transfer_number = wtx.open_table(HEIGHT_TO_LAST_TRANSFER_NUMBER)?;
     let mut home_inscriptions = wtx.open_table(HOME_INSCRIPTIONS)?;
+    let mut sequence_number_to_transfer_number =
+      wtx.open_multimap_table(SEQUENCE_NUMBER_TO_TRANSFER_NUMBER)?;
     let mut inscription_number_to_sequence_number =
       wtx.open_table(INSCRIPTION_NUMBER_TO_SEQUENCE_NUMBER)?;
     let mut latest_child_to_collection =
@@ -435,11 +439,14 @@ impl Updater<'_> {
       wtx.open_table(OUTPOINT_TO_FILTERED_INSCRIPTION_DATA)?;
     let mut outpoint_to_utxo_entry = wtx.open_table(OUTPOINT_TO_UTXO_ENTRY)?;
     let mut sat_to_satpoint = wtx.open_table(SAT_TO_SATPOINT)?;
+    let mut script_pubkey_to_transfer_number =
+      wtx.open_multimap_table(SCRIPT_PUBKEY_TO_TRANSFER_NUMBER)?;
     let mut sat_to_sequence_number = wtx.open_multimap_table(SAT_TO_SEQUENCE_NUMBER)?;
     let mut script_pubkey_to_outpoint = wtx.open_multimap_table(SCRIPT_PUBKEY_TO_OUTPOINT)?;
     let mut sequence_number_to_children = wtx.open_multimap_table(SEQUENCE_NUMBER_TO_CHILDREN)?;
     let mut sequence_number_to_inscription_entry =
       wtx.open_table(SEQUENCE_NUMBER_TO_INSCRIPTION_ENTRY)?;
+    let mut transfer_number_to_event = wtx.open_table(TRANSFER_NUMBER_TO_EVENT)?;
     let mut transaction_id_to_transaction = wtx.open_table(TRANSACTION_ID_TO_TRANSACTION)?;
 
     let index_inscriptions = self.height >= self.index.settings.first_inscription_height()
@@ -519,6 +526,13 @@ impl Updater<'_> {
       .map(|(number, _id)| number.value() + 1)
       .unwrap_or(0);
 
+    let next_transfer_number = transfer_number_to_event
+      .iter()?
+      .next_back()
+      .transpose()?
+      .map(|(number, _event)| number.value() + 1)
+      .unwrap_or(0);
+
     let home_inscription_count = home_inscriptions.len()?;
 
     let mut inscription_updater = InscriptionUpdater {
@@ -531,15 +545,19 @@ impl Updater<'_> {
       home_inscription_count,
       home_inscriptions: &mut home_inscriptions,
       id_to_sequence_number: inscription_id_to_sequence_number,
+      sequence_number_to_transfer_number: &mut sequence_number_to_transfer_number,
       inscription_number_to_sequence_number: &mut inscription_number_to_sequence_number,
       latest_child_to_collection: &mut latest_child_to_collection,
       lost_sats,
       next_sequence_number,
+      next_transfer_number,
       reward: Height(self.height).subsidy(),
       sat_to_sequence_number: &mut sat_to_sequence_number,
+      script_pubkey_to_transfer_number: &mut script_pubkey_to_transfer_number,
       sequence_number_to_children: &mut sequence_number_to_children,
       sequence_number_to_entry: &mut sequence_number_to_inscription_entry,
       timestamp: block.header.time,
+      transfer_number_to_event: &mut transfer_number_to_event,
       transaction_buffer: Vec::new(),
       transaction_id_to_transaction: &mut transaction_id_to_transaction,
       unbound_inscriptions,
@@ -702,6 +720,8 @@ impl Updater<'_> {
     if index_inscriptions {
       height_to_last_sequence_number
         .insert(&self.height, inscription_updater.next_sequence_number)?;
+      height_to_last_transfer_number
+        .insert(&self.height, &inscription_updater.next_transfer_number)?;
     }
 
     if !lost_sat_ranges.is_empty() {

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -711,13 +711,15 @@ impl InscriptionUpdater<'_, '_> {
           .id_to_sequence_number
           .insert(&inscription_id.store(), sequence_number)?;
 
-        self.index_transfer_history_event(
-          index,
-          sequence_number,
-          None,
-          destination_script_pubkey,
-          op_return,
-        )?;
+        if !unbound {
+          self.index_transfer_history_event(
+            index,
+            sequence_number,
+            None,
+            destination_script_pubkey,
+            op_return,
+          )?;
+        }
 
         if !hidden {
           self

--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -2,7 +2,7 @@ use super::{
   inscription_updater_filtered::{
     InscribedOffset, parse_filtered_inscription_data, record_filtered_inscription_data,
   },
-  *,
+  transfer_history_indexer, *,
 };
 
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -41,6 +41,7 @@ enum Origin {
   Old {
     sequence_number: u32,
     old_satpoint: SatPoint,
+    sender_script_pubkey: Option<Vec<u8>>,
   },
   OldFiltered {
     cursed_or_vindicated: bool,
@@ -66,15 +67,19 @@ pub(super) struct InscriptionUpdater<'a, 'tx> {
   pub(super) home_inscription_count: u64,
   pub(super) home_inscriptions: &'a mut Table<'tx, u32, InscriptionIdValue>,
   pub(super) id_to_sequence_number: &'a mut Table<'tx, InscriptionIdValue, u32>,
+  pub(super) sequence_number_to_transfer_number: &'a mut MultimapTable<'tx, u32, u64>,
   pub(super) inscription_number_to_sequence_number: &'a mut Table<'tx, i32, u32>,
   pub(super) latest_child_to_collection: &'a mut MultimapTable<'tx, u32, u32>,
   pub(super) lost_sats: u64,
   pub(super) next_sequence_number: u32,
+  pub(super) next_transfer_number: u64,
   pub(super) reward: u64,
   pub(super) sat_to_sequence_number: &'a mut MultimapTable<'tx, u64, u32>,
+  pub(super) script_pubkey_to_transfer_number: &'a mut MultimapTable<'tx, &'static [u8], u64>,
   pub(super) sequence_number_to_children: &'a mut MultimapTable<'tx, u32, u32>,
   pub(super) sequence_number_to_entry: &'a mut Table<'tx, u32, InscriptionEntryValue>,
   pub(super) timestamp: u32,
+  pub(super) transfer_number_to_event: &'a mut Table<'tx, u64, InscriptionTransferEventValue>,
   pub(super) transaction_buffer: Vec<u8>,
   pub(super) transaction_id_to_transaction: &'a mut Table<'tx, &'static TxidValue, &'static [u8]>,
   pub(super) unbound_inscriptions: u64,
@@ -120,6 +125,12 @@ impl InscriptionUpdater<'_, '_> {
 
       transferred_inscriptions.sort_by_key(|(sequence_number, _)| *sequence_number);
 
+      let sender_script_pubkey = index
+        .index_addresses
+        .then(|| input_utxo_entries[input_index].script_pubkey())
+        .filter(|script_pubkey| !script_pubkey.is_empty())
+        .map(<[u8]>::to_vec);
+
       for (sequence_number, old_satpoint_offset) in transferred_inscriptions {
         let old_satpoint = SatPoint {
           outpoint: txin.previous_output,
@@ -142,6 +153,7 @@ impl InscriptionUpdater<'_, '_> {
           origin: Origin::Old {
             sequence_number,
             old_satpoint,
+            sender_script_pubkey: sender_script_pubkey.clone(),
           },
         });
 
@@ -364,13 +376,14 @@ impl InscriptionUpdater<'_, '_> {
           new_satpoint,
           inscriptions.next().unwrap(),
           txout.script_pubkey.is_op_return(),
+          txout.script_pubkey.as_bytes().to_vec(),
         ));
       }
 
       output_value = end;
     }
 
-    for (new_satpoint, flotsam, op_return) in new_locations.into_iter() {
+    for (new_satpoint, flotsam, op_return, destination_script_pubkey) in new_locations.into_iter() {
       let output_utxo_entry =
         &mut output_utxo_entries[usize::try_from(new_satpoint.outpoint.vout).unwrap()];
 
@@ -380,6 +393,7 @@ impl InscriptionUpdater<'_, '_> {
         new_satpoint,
         op_return,
         &mut filtered_inscription_data_cache,
+        Some(destination_script_pubkey.as_slice()),
         Some(output_utxo_entry),
         utxo_cache,
         index,
@@ -398,6 +412,7 @@ impl InscriptionUpdater<'_, '_> {
           new_satpoint,
           false,
           &mut filtered_inscription_data_cache,
+          None,
           None,
           utxo_cache,
           index,
@@ -435,6 +450,28 @@ impl InscriptionUpdater<'_, '_> {
     unreachable!()
   }
 
+  fn index_transfer_history_event(
+    &mut self,
+    index: &Index,
+    sequence_number: u32,
+    sender_script_pubkey: Option<&[u8]>,
+    destination_script_pubkey: Option<&[u8]>,
+    op_return: bool,
+  ) -> Result {
+    transfer_history_indexer::index_transfer_history_event(
+      index,
+      self.height,
+      &mut self.next_transfer_number,
+      &mut *self.sequence_number_to_transfer_number,
+      &mut *self.script_pubkey_to_transfer_number,
+      &mut *self.transfer_number_to_event,
+      sequence_number,
+      sender_script_pubkey,
+      destination_script_pubkey,
+      op_return,
+    )
+  }
+
   fn update_inscription_location(
     &mut self,
     input_sat_ranges: Option<&Vec<&[u8]>>,
@@ -442,6 +479,7 @@ impl InscriptionUpdater<'_, '_> {
     new_satpoint: SatPoint,
     op_return: bool,
     filtered_inscription_data_cache: &mut Option<&mut HashMap<OutPoint, Vec<u8>>>,
+    destination_script_pubkey: Option<&[u8]>,
     mut normal_output_utxo_entry: Option<&mut UtxoEntryBuf>,
     utxo_cache: &mut HashMap<OutPoint, UtxoEntryBuf>,
     index: &Index,
@@ -456,6 +494,7 @@ impl InscriptionUpdater<'_, '_> {
       Origin::Old {
         sequence_number,
         old_satpoint,
+        sender_script_pubkey,
       } => {
         let inscription_id = inscription_id.expect("old flotsam must have inscription ID");
 
@@ -486,6 +525,14 @@ impl InscriptionUpdater<'_, '_> {
             sequence_number,
           })?;
         }
+
+        self.index_transfer_history_event(
+          index,
+          sequence_number,
+          sender_script_pubkey.as_deref(),
+          destination_script_pubkey,
+          op_return,
+        )?;
 
         (false, sequence_number)
       }
@@ -663,6 +710,14 @@ impl InscriptionUpdater<'_, '_> {
         self
           .id_to_sequence_number
           .insert(&inscription_id.store(), sequence_number)?;
+
+        self.index_transfer_history_event(
+          index,
+          sequence_number,
+          None,
+          destination_script_pubkey,
+          op_return,
+        )?;
 
         if !hidden {
           self

--- a/src/index/updater/transfer_history_indexer.rs
+++ b/src/index/updater/transfer_history_indexer.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+fn script_pubkey_is_address(index: &Index, script_pubkey: &[u8]) -> bool {
+  let script_pubkey_buf = ScriptBuf::from_bytes(script_pubkey.to_vec());
+  index
+    .settings
+    .chain()
+    .address_from_script(&script_pubkey_buf)
+    .is_ok()
+}
+
+pub(super) fn index_transfer_history_event(
+  index: &Index,
+  block_height: u32,
+  next_transfer_number: &mut u64,
+  sequence_number_to_transfer_number: &mut MultimapTable<'_, u32, u64>,
+  script_pubkey_to_transfer_number: &mut MultimapTable<'_, &'static [u8], u64>,
+  transfer_number_to_event: &mut Table<'_, u64, InscriptionTransferEventValue>,
+  sequence_number: u32,
+  sender_script_pubkey: Option<&[u8]>,
+  destination_script_pubkey: Option<&[u8]>,
+  op_return: bool,
+) -> Result {
+  if !index.index_addresses {
+    return Ok(());
+  }
+
+  let sender_script_pubkey = sender_script_pubkey
+    .filter(|script_pubkey| !script_pubkey.is_empty())
+    .map(<[u8]>::to_vec);
+
+  let destination_script_pubkey = destination_script_pubkey
+    .filter(|script_pubkey| !script_pubkey.is_empty())
+    .filter(|_| !op_return)
+    .map(<[u8]>::to_vec);
+
+  let sender_address_script_pubkey = sender_script_pubkey
+    .as_deref()
+    .filter(|script_pubkey| script_pubkey_is_address(index, script_pubkey));
+  let destination_address_script_pubkey = destination_script_pubkey
+    .as_deref()
+    .filter(|script_pubkey| script_pubkey_is_address(index, script_pubkey));
+
+  let transfer_number = *next_transfer_number;
+
+  transfer_number_to_event.insert(
+    &transfer_number,
+    &InscriptionTransferEvent {
+      block_height,
+      sequence_number,
+      from_script_pubkey: sender_script_pubkey.clone().unwrap_or_default(),
+      to_script_pubkey: destination_script_pubkey.clone(),
+    }
+    .store(),
+  )?;
+
+  sequence_number_to_transfer_number.insert(&sequence_number, &transfer_number)?;
+
+  if let Some(sender_script_pubkey) = sender_address_script_pubkey {
+    script_pubkey_to_transfer_number.insert(sender_script_pubkey, &transfer_number)?;
+  }
+
+  if let Some(destination_script_pubkey) = destination_address_script_pubkey
+    && sender_address_script_pubkey != Some(destination_script_pubkey)
+  {
+    script_pubkey_to_transfer_number.insert(destination_script_pubkey, &transfer_number)?;
+  }
+
+  *next_transfer_number += 1;
+
+  Ok(())
+}

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -449,7 +449,15 @@ impl Server {
       }
     };
 
-    let addr = (address, port)
+    // In test mode, avoid binding privileged HTTPS port 443 while preserving
+    // the configured port value used for redirect URL generation.
+    let bind_port = if cfg!(test) && matches!(&config, SpawnConfig::Https(_)) && port == 443 {
+      0
+    } else {
+      port
+    };
+
+    let addr = (address, bind_port)
       .to_socket_addrs()?
       .next()
       .ok_or_else(|| anyhow!("failed to get socket addrs"))?;


### PR DESCRIPTION
## Summary
- add durable Redb transfer-history indexes keyed by inscription and script pubkey
- persist history events with `sequence_number`, `from/to` script pubkeys, and block height
- include both inscription creation and transfers in history
- expose `Index` query APIs for paginated inscription and address history (newest first)
- return `from_address` / `to_address` in history entries
- index history only when `--index-addresses` is enabled
- index sender+receiver for address-decodable destinations, and sender-only for OP_RETURN/non-address destinations
- dedupe sender/receiver mapping when both script pubkeys are identical

## Schema
- bump index schema version to 34
- add:
  - `TRANSFER_NUMBER_TO_EVENT`
  - `INSCRIPTION_ID_TO_TRANSFER_NUMBER`
  - `SCRIPT_PUBKEY_TO_TRANSFER_NUMBER`

## Tests
- added history behavior tests in `src/index.rs`
- added transfer-event entry encoding roundtrip test in `src/index/entry.rs`
- validated with:
  - `cargo test --lib transfer_history -- --nocapture`
  - `cargo test --lib sender_receiver_same_script_is_deduped -- --nocapture`
  - `cargo test --lib inscription_transfer_event_entry -- --nocapture`
