### PR TITLE
Add pre-jubilee filtered data cleanup command

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -922,6 +922,32 @@ impl Index {
     Ok(())
   }
 
+  pub(crate) fn cleanup_pre_jubilee_filtered_inscription_data(&self) -> Result<(u64, u64, bool)> {
+    let wtx = self.database.begin_write()?;
+
+    let rows_before = wtx
+      .open_table(OUTPOINT_TO_FILTERED_INSCRIPTION_DATA)?
+      .len()?;
+
+    let table_deleted = wtx.delete_table(OUTPOINT_TO_FILTERED_INSCRIPTION_DATA)?;
+
+    wtx.open_table(OUTPOINT_TO_FILTERED_INSCRIPTION_DATA)?;
+
+    wtx.commit()?;
+
+    // Commit twice since due to a bug redb will only reuse pages freed in the
+    // transaction before last.
+    self.begin_write()?.commit()?;
+
+    let rows_after = self
+      .database
+      .begin_read()?
+      .open_table(OUTPOINT_TO_FILTERED_INSCRIPTION_DATA)?
+      .len()?;
+
+    Ok((rows_before, rows_after, table_deleted))
+  }
+
   #[cfg(test)]
   pub(crate) fn inscription_number(&self, inscription_id: InscriptionId) -> i32 {
     self

--- a/src/subcommand/index.rs
+++ b/src/subcommand/index.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+mod cleanup;
 mod export;
 pub mod info;
 mod update;
@@ -8,6 +9,8 @@ mod update;
 pub(crate) enum IndexSubcommand {
   #[command(about = "Write inscription numbers and ids to a tab-separated file")]
   Export(export::Export),
+  #[command(about = "Clean up index data")]
+  Cleanup(cleanup::Cleanup),
   #[command(about = "Print index statistics")]
   Info(info::Info),
   #[command(about = "Update the index", alias = "run")]
@@ -18,6 +21,7 @@ impl IndexSubcommand {
   pub(crate) fn run(self, settings: Settings) -> SubcommandResult {
     match self {
       Self::Export(export) => export.run(settings),
+      Self::Cleanup(cleanup) => cleanup.run(settings),
       Self::Info(info) => info.run(settings),
       Self::Update => update::run(settings),
     }

--- a/src/subcommand/index/cleanup.rs
+++ b/src/subcommand/index/cleanup.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+#[derive(Debug, Parser)]
+pub(crate) struct Cleanup {
+  #[arg(long, help = "Delete pre-jubilee filtered inscription shadow data.")]
+  pre_jubilee_filtered: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub struct Output {
+  pub rows_before: u64,
+  pub rows_after: u64,
+  pub table_deleted: bool,
+}
+
+impl Cleanup {
+  pub(crate) fn run(self, settings: Settings) -> SubcommandResult {
+    if !self.pre_jubilee_filtered {
+      bail!("no cleanup target selected, pass --pre-jubilee-filtered");
+    }
+
+    let index = Index::open(&settings)?;
+    let (rows_before, rows_after, table_deleted) =
+      index.cleanup_pre_jubilee_filtered_inscription_data()?;
+
+    Ok(Some(Box::new(Output {
+      rows_before,
+      rows_after,
+      table_deleted,
+    })))
+  }
+}

--- a/tests/index.rs
+++ b/tests/index.rs
@@ -1,4 +1,12 @@
 use super::*;
+use redb::{Database, TableDefinition};
+
+#[derive(serde::Deserialize)]
+struct CleanupOutput {
+  rows_before: u64,
+  rows_after: u64,
+  table_deleted: bool,
+}
 
 #[test]
 fn run_is_an_alias_for_update() {
@@ -89,4 +97,53 @@ fn export_inscription_number_to_id_tsv() {
     entries.get(&2).unwrap(),
     &ord::Object::InscriptionId(inscription),
   );
+}
+
+#[test]
+fn cleanup_pre_jubilee_filtered_shadow_data_is_idempotent() {
+  let core = mockcore::spawn();
+  core.mine_blocks(1);
+
+  let tempdir = TempDir::new().unwrap();
+
+  let index_path = tempdir.path().join("foo.redb");
+
+  CommandBuilder::new(format!("--index {} index update", index_path.display()))
+    .core(&core)
+    .run_and_extract_stdout();
+
+  const OUTPOINT_TO_FILTERED_INSCRIPTION_DATA: TableDefinition<&[u8; 36], &[u8]> =
+    TableDefinition::new("OUTPOINT_TO_FILTERED_INSCRIPTION_DATA");
+
+  let database = Database::builder().open(&index_path).unwrap();
+  let wtx = database.begin_write().unwrap();
+  wtx
+    .open_table(OUTPOINT_TO_FILTERED_INSCRIPTION_DATA)
+    .unwrap()
+    .insert(&[0; 36], &[1_u8, 2, 3][..])
+    .unwrap();
+  wtx.commit().unwrap();
+  drop(database);
+
+  let first_cleanup = CommandBuilder::new(format!(
+    "--index {} index cleanup --pre-jubilee-filtered",
+    index_path.display()
+  ))
+  .core(&core)
+  .run_and_deserialize_output::<CleanupOutput>();
+
+  assert!(first_cleanup.table_deleted);
+  assert!(first_cleanup.rows_before > 0);
+  assert_eq!(first_cleanup.rows_after, 0);
+
+  let second_cleanup = CommandBuilder::new(format!(
+    "--index {} index cleanup --pre-jubilee-filtered",
+    index_path.display()
+  ))
+  .core(&core)
+  .run_and_deserialize_output::<CleanupOutput>();
+
+  assert!(second_cleanup.table_deleted);
+  assert_eq!(second_cleanup.rows_before, 0);
+  assert_eq!(second_cleanup.rows_after, 0);
 }


### PR DESCRIPTION
## Summary
- add `ord index cleanup --pre-jubilee-filtered`
- delete and recreate `OUTPOINT_TO_FILTERED_INSCRIPTION_DATA`
- run second commit for redb page-reuse behavior
- return cleanup stats in JSON output (`rows_before`, `rows_after`, `table_deleted`)

## Notes
- transfer event/script-id storage changes were intentionally removed for simplicity
- transfer indexing behavior and APIs remain unchanged

## Tests
- `cargo test --lib transfer_event -- --nocapture`
- `cargo test --lib transfer_history_tests -- --nocapture`
- `cargo test --lib transfer_history_endpoints -- --nocapture`
- `cargo test --lib brc20_filter_tests -- --nocapture`
- `cargo test --test integration index::cleanup_pre_jubilee_filtered_shadow_data_is_idempotent -- --nocapture`
